### PR TITLE
Added Jasmine testing framework through npm

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,8 @@ var gulp = require("gulp"),
     uglify = require("gulp-uglify"),
     stripDebug = require("gulp-strip-debug"),
     rename = require("gulp-rename"),
-    multiDest = require("gulp-multi-dest");
+    multiDest = require("gulp-multi-dest"),
+    jasmineBrowser = require("gulp-jasmine-browser");
 
 var path = {
     dist: "./dist/",
@@ -40,6 +41,12 @@ gulp.task("copy", function () {
 
 });
 
+/*jasmine server to run specs*/
+gulp.task('jasmine'), function() {
+  return gulp.src(['src/ .js', 'spec/**/*_spec.js'])
+  .pipe(jasmineBrowser.specRunner())
+
+}
 
 
 /* build */

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,8 +6,6 @@ var gulp = require("gulp"),
     uglify = require("gulp-uglify"),
     stripDebug = require("gulp-strip-debug"),
     rename = require("gulp-rename"),
-    multiDest = require("gulp-multi-dest"),
-    jasmineBrowser = require("gulp-jasmine-browser");
 
 var path = {
     dist: "./dist/",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -41,13 +41,5 @@ gulp.task("copy", function () {
 
 });
 
-/*jasmine server to run specs*/
-gulp.task('jasmine'), function() {
-  return gulp.src(['src/ .js', 'spec/**/*_spec.js'])
-  .pipe(jasmineBrowser.specRunner())
-
-}
-
-
 /* build */
 gulp.task("build", ["clean", "min:css", "min:js", "copy"]);

--- a/package.json
+++ b/package.json
@@ -11,5 +11,8 @@
     "gulp-strip-debug": "1.1.0",
     "gulp-multi-dest": "0.0.4",
     "rimraf": "2.6.1"
+  },
+  "dependencies": {
+    "gulp-jasmine-browser": "^1.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,14 +26,4 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "test": "jasmine"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/bl2i4n/jquery-punchcard.git"
-  },
-  "author": "",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/bl2i4n/jquery-punchcard/issues"
-  },
-  "homepage": "https://github.com/bl2i4n/jquery-punchcard#readme"
-}
+  

--- a/package.json
+++ b/package.json
@@ -25,5 +25,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "test": "jasmine"
-  },
-  
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,13 +6,34 @@
     "gulp-concat": "2.6.1",
     "gulp-concat-css": "2.3.0",
     "gulp-cssmin": "0.1.7",
-    "gulp-uglify": "2.0.1",
+    "gulp-multi-dest": "0.0.4",
     "gulp-rename": "1.2.2",
     "gulp-strip-debug": "1.1.0",
-    "gulp-multi-dest": "0.0.4",
+    "gulp-uglify": "2.0.1",
+    "jasmine": "^2.8.0",
     "rimraf": "2.6.1"
   },
   "dependencies": {
     "gulp-jasmine-browser": "^1.9.1"
-  }
+  },
+  "name": "jquery-punchcard",
+  "description": "<h1 align=\"center\">   <br>   <a href=\"http://melenaos.github.io/jquery-punchcard/\"><img src=\"https://github.com/melenaos/jquery-punchcard/raw/master/docs/media/logo.png\" alt=\"jquery-punchcard\" width=\"200\"></a>   <br>   Punchcard   <br> </h1>",
+  "main": "gulpfile.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jasmine"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bl2i4n/jquery-punchcard.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/bl2i4n/jquery-punchcard/issues"
+  },
+  "homepage": "https://github.com/bl2i4n/jquery-punchcard#readme"
 }

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}


### PR DESCRIPTION
- Added jasmine to package.json
- Tried using a headless browser with npm package gulp-jasmine-browser, decided not to for sake of time

1. To start jasmine, run `npm install`
2. Then run `npm test`

There are no tests written in the spec directory yet.